### PR TITLE
Fix broken UI issue

### DIFF
--- a/TruexGoogleReferenceApp/src/main/java/com/truex/googlereferenceapp/player/VideoPlaybackManager.java
+++ b/TruexGoogleReferenceApp/src/main/java/com/truex/googlereferenceapp/player/VideoPlaybackManager.java
@@ -430,8 +430,8 @@ public class VideoPlaybackManager implements PlaybackHandler, AdEvent.AdEventLis
         // Add the duration of the ad break
         seekPosition.addSeconds(adProgressInfo.getAdBreakDuration());
 
-        // Add three hundred milliseconds to avoid displaying a black screen with a frozen UI
-        seekPosition.addMilliseconds(300);
+        // Add two seconds to avoid displaying a frozen UI
+        seekPosition.addSeconds(2);
 
         // Seek past the ad break
         videoPlayer.seekTo(seekPosition);

--- a/TruexGoogleReferenceApp/src/main/java/com/truex/googlereferenceapp/util/FileUtils.java
+++ b/TruexGoogleReferenceApp/src/main/java/com/truex/googlereferenceapp/util/FileUtils.java
@@ -14,6 +14,10 @@ public final class FileUtils {
     }
 
     public static String getRawFileContents(Context context, int resourceId) {
+        if (context == null) {
+            return null;
+        }
+
         InputStream vastContentStream = context.getResources().openRawResource(resourceId);
 
         StringBuilder stringBuilder = new StringBuilder();


### PR DESCRIPTION
For the second ad pod, the UI was freezing
after the skip card. This was due to a bug
in the video player. When we don't skip at
least ~2 seconds past the end of the ad
break, the user will be stuck with a frozen
UI. With a two second additional skip-ahead
this issue does not reproduce.