### PR TITLE
PI-1815: migrate to new S3 maven repo and TAR v2.1.2

### DIFF
--- a/TruexGoogleReferenceApp/build.gradle
+++ b/TruexGoogleReferenceApp/build.gradle
@@ -43,5 +43,5 @@ dependencies {
     implementation 'com.google.dagger:dagger-android-support:2.20'
     annotationProcessor 'com.google.dagger:dagger-android-processor:2.20'
     annotationProcessor 'com.google.dagger:dagger-compiler:2.20'
-    implementation 'com.truex:TruexAdRenderer-tv:2.1.2'
+    implementation 'com.truex:TruexAdRenderer-tv:2.1.3'
 }

--- a/TruexGoogleReferenceApp/build.gradle
+++ b/TruexGoogleReferenceApp/build.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 27
+    compileSdkVersion 28
     defaultConfig {
         applicationId "com.truex.googlereferenceapp"
         minSdkVersion 21
@@ -23,7 +23,7 @@ android {
 
 repositories {
     maven {
-        url "https://raw.github.com/socialvibe/truex-tv-integrations/android"
+        url "http://ctv.truex.com.s3.amazonaws.com/android/maven"
     }
 }
 
@@ -33,23 +33,16 @@ dependencies {
     implementation 'com.android.support:support-v4:27.1.1'
     implementation 'com.android.support:recyclerview-v7:27.1.1'
     implementation 'com.android.support:customtabs:27.1.1'
-
     implementation 'com.google.ads.interactivemedia.v3:interactivemedia:3.10.9'
     implementation 'com.google.android.gms:play-services-ads:17.2.0'
-
     implementation 'com.google.android.exoplayer:exoplayer:2.8.0'
-
     implementation 'com.squareup.okhttp3:okhttp:3.10.0'
-
     implementation 'com.github.bumptech.glide:glide:4.9.0'
     annotationProcessor 'com.github.bumptech.glide:compiler:4.9.0'
-
     implementation 'com.github.medyo:fancybuttons:1.9.1'
-
     implementation 'com.google.dagger:dagger-android:2.20'
     implementation 'com.google.dagger:dagger-android-support:2.20'
     annotationProcessor 'com.google.dagger:dagger-android-processor:2.20'
     annotationProcessor 'com.google.dagger:dagger-compiler:2.20'
-
     implementation 'com.truex:TruexAdRenderer-tv:2.1.0'
 }

--- a/TruexGoogleReferenceApp/build.gradle
+++ b/TruexGoogleReferenceApp/build.gradle
@@ -4,7 +4,7 @@ android {
     compileSdkVersion 28
     defaultConfig {
         applicationId "com.truex.googlereferenceapp"
-        minSdkVersion 21
+        minSdkVersion 25
         targetSdkVersion 27
         versionCode 1
         versionName "1.0"
@@ -23,18 +23,17 @@ android {
 
 repositories {
     maven {
-        url "http://ctv.truex.com.s3.amazonaws.com/android/maven"
+        url "https://ctv.truex.com/android/maven"
     }
 }
 
 dependencies {
     implementation fileTree(include: ['*.jar'], dir: 'libs')
-    implementation 'com.android.support:appcompat-v7:27.1.1'
-    implementation 'com.android.support:support-v4:27.1.1'
-    implementation 'com.android.support:recyclerview-v7:27.1.1'
-    implementation 'com.android.support:customtabs:27.1.1'
+    implementation 'androidx.appcompat:appcompat:1.0.0'
+    implementation 'androidx.legacy:legacy-support-v4:1.0.0'
+    implementation 'androidx.recyclerview:recyclerview:1.0.0-beta01'
+    implementation 'androidx.browser:browser:1.0.0-beta01'
     implementation 'com.google.ads.interactivemedia.v3:interactivemedia:3.10.9'
-    implementation 'com.google.android.gms:play-services-ads:17.2.0'
     implementation 'com.google.android.exoplayer:exoplayer:2.8.0'
     implementation 'com.squareup.okhttp3:okhttp:3.10.0'
     implementation 'com.github.bumptech.glide:glide:4.9.0'
@@ -44,5 +43,5 @@ dependencies {
     implementation 'com.google.dagger:dagger-android-support:2.20'
     annotationProcessor 'com.google.dagger:dagger-android-processor:2.20'
     annotationProcessor 'com.google.dagger:dagger-compiler:2.20'
-    implementation 'com.truex:TruexAdRenderer-tv:2.1.0'
+    implementation 'com.truex:TruexAdRenderer-tv:2.1.2'
 }

--- a/TruexGoogleReferenceApp/build.gradle
+++ b/TruexGoogleReferenceApp/build.gradle
@@ -1,11 +1,11 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 28
+    compileSdkVersion 30
     defaultConfig {
         applicationId "com.truex.googlereferenceapp"
         minSdkVersion 25
-        targetSdkVersion 27
+        targetSdkVersion 30
         versionCode 1
         versionName "1.0"
     }

--- a/TruexGoogleReferenceApp/src/main/AndroidManifest.xml
+++ b/TruexGoogleReferenceApp/src/main/AndroidManifest.xml
@@ -16,7 +16,9 @@
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
         android:supportsRtl="true"
-        android:theme="@style/AppTheme">
+        android:theme="@style/AppTheme"
+        android:usesCleartextTraffic="true"
+        android:networkSecurityConfig="@xml/network_security_config">
 
         <meta-data
             android:name="com.google.android.gms.ads.AD_MANAGER_APP"

--- a/TruexGoogleReferenceApp/src/main/java/com/truex/googlereferenceapp/MainActivity.java
+++ b/TruexGoogleReferenceApp/src/main/java/com/truex/googlereferenceapp/MainActivity.java
@@ -1,6 +1,6 @@
 package com.truex.googlereferenceapp;
 
-import android.support.v4.app.Fragment;
+import androidx.fragment.app.Fragment;
 import android.os.Bundle;
 import android.view.Window;
 import android.view.WindowManager;

--- a/TruexGoogleReferenceApp/src/main/java/com/truex/googlereferenceapp/home/HomeViewFragment.java
+++ b/TruexGoogleReferenceApp/src/main/java/com/truex/googlereferenceapp/home/HomeViewFragment.java
@@ -1,8 +1,8 @@
 package com.truex.googlereferenceapp.home;
 
 import android.os.Bundle;
-import android.support.annotation.NonNull;
-import android.support.v4.app.Fragment;
+import androidx.annotation.NonNull;
+import androidx.fragment.app.Fragment;
 import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;

--- a/TruexGoogleReferenceApp/src/main/java/com/truex/googlereferenceapp/home/StreamConfiguration.java
+++ b/TruexGoogleReferenceApp/src/main/java/com/truex/googlereferenceapp/home/StreamConfiguration.java
@@ -2,7 +2,7 @@ package com.truex.googlereferenceapp.home;
 
 import android.os.Parcel;
 import android.os.Parcelable;
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 import android.util.Log;
 
 import org.json.JSONArray;

--- a/TruexGoogleReferenceApp/src/main/java/com/truex/googlereferenceapp/player/PlayerViewFragment.java
+++ b/TruexGoogleReferenceApp/src/main/java/com/truex/googlereferenceapp/player/PlayerViewFragment.java
@@ -1,8 +1,8 @@
 package com.truex.googlereferenceapp.player;
 
 import android.os.Bundle;
-import android.support.annotation.NonNull;
-import android.support.v4.app.Fragment;
+import androidx.annotation.NonNull;
+import androidx.fragment.app.Fragment;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;

--- a/TruexGoogleReferenceApp/src/main/java/com/truex/googlereferenceapp/player/ads/TruexAdManager.java
+++ b/TruexGoogleReferenceApp/src/main/java/com/truex/googlereferenceapp/player/ads/TruexAdManager.java
@@ -4,7 +4,7 @@ import android.content.Context;
 import android.util.Log;
 import android.view.ViewGroup;
 
-import com.truex.adrenderer.IEventHandler;
+import com.truex.adrenderer.IEventEmitter.IEventHandler;
 import com.truex.adrenderer.TruexAdRenderer;
 import com.truex.adrenderer.TruexAdRendererConstants;
 

--- a/TruexGoogleReferenceApp/src/main/res/raw/stream_config_fallback.json
+++ b/TruexGoogleReferenceApp/src/main/res/raw/stream_config_fallback.json
@@ -1,8 +1,8 @@
 {
   "title" : "Day in the Life of a Product Manager",
   "description" : "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Ut dictum, diam sed gravida tincidunt, libero lectus maximus elit, eget scelerisque ex orci a massa. Nullam ut mi ut lectus molestie porta.",
-  "cover" : "https://stash.truex.com/reference-apps/scratch/truex_cover_placeholder_spaceneedle.png",
-  "preview" : "https://media.truex.com/video_assets/2017-03-06/a9fbc895-6987-440e-b940-eeef8a714338_large.mp4",
+  "cover" : "http://stash.truex.com/reference-apps/scratch/truex_cover_placeholder_spaceneedle.png",
+  "preview" : "http://media.truex.com/video_assets/2017-03-06/a9fbc895-6987-440e-b940-eeef8a714338_large.mp4",
   "google_content_id" : "2496857",
   "google_video_id" : "truex-content22-4k"
 }

--- a/TruexGoogleReferenceApp/src/main/res/xml/network_security_config.xml
+++ b/TruexGoogleReferenceApp/src/main/res/xml/network_security_config.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<network-security-config>
+    <domain-config cleartextTrafficPermitted="true">
+        <domain includeSubdomains="true">media.truex.com</domain>
+    </domain-config>
+</network-security-config>

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,6 +6,8 @@
 # http://www.gradle.org/docs/current/userguide/build_environment.html
 # Specifies the JVM arguments used for the daemon process.
 # The setting is particularly useful for tweaking memory settings.
+android.enableJetifier=true
+android.useAndroidX=true
 org.gradle.jvmargs=-Xmx1536m
 # When configured, Gradle will run in incubating parallel mode.
 # This option should only be used with decoupled projects. More details, visit


### PR DESCRIPTION
**v2.1.3 update**: the transition to API level 30 meant a lot of stuff utilizing HTTPS started breaking. Namely, the video streams used by the app for the reference app failed to play in ExoPlayer, with error messages complaining about a missing link in the trust chain, or some such. Well, the S3 end point we're using is certainly legit from an SSL standpoint (verified in `https://www.digicert.com/help/`). Googling around, I couldn't figure out why there would be a problem playing this stream, while pulling the true[X] tag's vast/config in HTTPS works in the same app. 

In `sheppard` I also tried to update the version of ExoPlayer, to no avail.

In the end I decided to whitelist the test videos for insecure playback. But I validated that this app works with the updated TAR that forces unqualified tags to use HTTPS instead of HTTP. See [PI-1820](https://truextech.atlassian.net/browse/PI-1820).

I tested in the emulator as well as on device.

---

These are the changes to upgrade `truex-android-google-ad-manager-reference-app` to TAR v2.1.2 and the new Maven repo.

It includes migration to AndroidX which was kind of forced by conflicting Google libs from TAR's own AndroidX migration.

It has the change to IEventHandler reflecting its refactor in TAR.

I did lightly dev test and validated a build from a clean gradle cache.