### PR TITLE
CTV-2262: migrate to new maven repo and TAR version

### DIFF
--- a/TruexGoogleReferenceApp/build.gradle
+++ b/TruexGoogleReferenceApp/build.gradle
@@ -23,7 +23,7 @@ android {
 
 repositories {
     maven {
-        url "https://ctv.truex.com/android/maven"
+        url "https://s3.amazonaws.com/android.truex.com/maven"
     }
 }
 
@@ -43,5 +43,5 @@ dependencies {
     implementation 'com.google.dagger:dagger-android-support:2.20'
     annotationProcessor 'com.google.dagger:dagger-android-processor:2.20'
     annotationProcessor 'com.google.dagger:dagger-compiler:2.20'
-    implementation 'com.truex:TruexAdRenderer-tv:2.1.3'
+    implementation 'com.truex:TruexAdRenderer-tv:2.2.1'
 }


### PR DESCRIPTION
This reference app also needed to be migrated over to v2.2.1 and the updated Maven repo

Behind the scenes I also updated the test ad to the same payload as `sheppard`. Details: https://truextech.atlassian.net/browse/CTV-2262