### PR TITLE
PI-3326: Fix premature ad auto-advance triggered by Infillion placeholders

### DIFF
--- a/TruexGoogleReferenceApp/src/main/java/com/truex/googlereferenceapp/player/VideoPlayerWithAds.java
+++ b/TruexGoogleReferenceApp/src/main/java/com/truex/googlereferenceapp/player/VideoPlayerWithAds.java
@@ -208,7 +208,7 @@ public class VideoPlayerWithAds implements PlaybackHandler, AdEvent.AdEventListe
         seekPosition.addSeconds(ad.getDuration());
 
         // Subtract a hundred milliseconds to avoid displaying a black screen with a frozen UI
-        seekPosition.subtractMilliseconds(100);
+        seekPosition.subtractMilliseconds(1001);
 
         // Seek past the ad
         videoPlayer.seekTo(seekPosition.getMilliseconds());

--- a/TruexGoogleReferenceApp/src/main/java/com/truex/googlereferenceapp/player/VideoPlayerWithAds.java
+++ b/TruexGoogleReferenceApp/src/main/java/com/truex/googlereferenceapp/player/VideoPlayerWithAds.java
@@ -207,7 +207,9 @@ public class VideoPlayerWithAds implements PlaybackHandler, AdEvent.AdEventListe
         // Add the duration of the initial ad
         seekPosition.addSeconds(ad.getDuration());
 
-        // Subtract a hundred milliseconds to avoid displaying a black screen with a frozen UI
+        // Subtract just over 1 second to stay outside IMA SDK's auto-advance threshold.
+        // The SDK auto-advances to the next ad when playhead is ≤1 second from ad end,
+        // causing duplicate STARTED events (problematic with back-to-back Infillion ads).
         seekPosition.subtractMilliseconds(1001);
 
         // Seek past the ad


### PR DESCRIPTION
## Problem
  When back-to-back Infillion (TrueX/IDVx) ads play in an ad pod, the second Infillion renderer was being incorrectly initialized, causing duplicate engagement displays.

  ## Root Cause
  The IMA SDK has a 1-second auto-advance threshold. When seeking to ≤1 second from an ad's end, the SDK automatically advances to the next ad and fires its STARTED event.

  This quirk always existed but was previously harmless:
  - **Before**: First ad (Infillion) → Second ad (regular video). The second STARTED for the video ad was inconsequential since the player was paused.
  - **Now**: First ad (Infillion) → Second ad (Infillion). The second STARTED causes a second Infillion renderer to initialize, creating a conflict.

  ## Solution
  Changed the seek offset from 100ms to 1001ms in `seekPastInitialAd()` to stay outside the IMA SDK's auto-advance threshold. This ensures `onAdStarted` fires predictably once per ad, preventing two Infillion renderers from displaying simultaniously.

  ## Testing
  - Verified back-to-back Infillion ads display correctly
  - Confirmed single STARTED event per ad, all fired at the expected interval (roughly 30 seconds apart or longer)
  - Tested mixed ad pods (Infillion + regular video ads)