### PR TITLE
PI-3326: Skip placeholder videos at the end of Infillion engagements

### DIFF
--- a/TruexGoogleReferenceApp/src/main/java/com/truex/googlereferenceapp/player/VideoPlayerWithAds.java
+++ b/TruexGoogleReferenceApp/src/main/java/com/truex/googlereferenceapp/player/VideoPlayerWithAds.java
@@ -300,6 +300,8 @@ public class VideoPlayerWithAds implements PlaybackHandler, AdEvent.AdEventListe
 
                 // Disable player controls
                 videoPlayer.enableControls(false);
+
+                lastAdEndTime = null;
             }
 
             @Override


### PR DESCRIPTION
Skipping placeholder videos at the beggining of Infillion engagements accelerated GAM progress and triggers the next ad. The solution is to skip the placeholder after the engagement is complete.